### PR TITLE
Added the Immunefi Boosts online interactive version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 If you're looking for the latest ones,those're most likely somewhere at the bottom
-- [Bug reports from Bounty Boosts](https://github.com/immunefi-team/Bounty_Boosts)
+- [Bug reports from Bounty Boosts](https://github.com/immunefi-team/Bounty_Boosts) (github) or [online interactive version](https://reports.immunefi.com/)
 - [Immunefi's Bug fix Reviews](https://github.com/immunefi-team/Web3-Security-Library/blob/main/BugFixReviews/README.md)
 - [All submitted reports of Beanstalk](https://community.bean.money/bug-reports)<br/>
 - [SCV-List](https://github.com/sirhashalot/SCV-List)


### PR DESCRIPTION
The PR just mentions the newly added https://reports.immunefi.com site as an alternative to the github version.

More details here: https://x.com/MitchellAmador/status/1832009021869437110 

Didn't think of any other way of coupling it with the github link. What do you think?